### PR TITLE
refactor definitionsview and onArchive function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "forge-hubs-browser-nodejs",
+  "name": "aps-mfgdatamodel-demo",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "forge-hubs-browser-nodejs",
+      "name": "aps-mfgdatamodel-demo",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -278,6 +278,7 @@
               <th scope="col">Description</th>
               <th scope="col">Hidden</th>
               <th scope="col">Read only</th>
+              <th scope="col">Archived</th>
               <th scope="col">Actions</th>
             </tr>
           </thead>

--- a/wwwroot/js/definitionsview.js
+++ b/wwwroot/js/definitionsview.js
@@ -92,15 +92,13 @@ async function onArchive(event) {
         );
       });
 
-      const definitionsTable = document.getElementById("definitionsTable");
-      const numOfRows = definitionsTable.rows.length;
-      if (numOfRows < 2) {
-        const collectionId = definitionsTable.getAttribute("collectionId");
-        const collectionName = definitionsTable.getAttribute("collectionName");
-        showDefinitionsTable(collectionId, collectionName, false, []);
-        return;
-      } else {
-        removeRow(definitionsTable, currentValues);
+      const row = document.querySelector(`tr[definitionid=${currentValues.id}]`);
+      
+      if (row) {
+        const archivedSpan = row.querySelector('.definition-archived');
+        if (archivedSpan) {
+          archivedSpan.textContent = 'Yes';
+        }
       }
     } catch (error) {
       showInfoDialog("error", null, error, null, "OK", () => {});
@@ -122,6 +120,7 @@ function addRow(definitionsTable, definition) {
     <td class="definition-description">${definition.description}</td>
     <td class="definition-hidden">${toYesOrNo(definition.isHidden)}</td>
     <td class="definition-readonly">${toYesOrNo(definition.isReadOnly)}</td>
+    <td class="definition-archived">${toYesOrNo(definition.isArchived)}</td>
     <td>
       <span href="" class="bi bi-pencil clickable" title="Edit property definition">&nbsp;</span>
       ${showArchive ? '<span href="" class="bi bi-archive clickable" title="Archive property">&nbsp;</span>' : ''}


### PR DESCRIPTION
When a user  archives a property definition, the demo app makes a GRAPHQL Call, and remove that property definition from the table.

With this PR, we are not going to remove the property definition from the table on archival, and also add a new column in the table to show the archive status of the property definition