### PR TITLE
remove archive button for archived property definitions

### DIFF
--- a/wwwroot/js/definitionsview.js
+++ b/wwwroot/js/definitionsview.js
@@ -96,8 +96,12 @@ async function onArchive(event) {
       
       if (row) {
         const archivedSpan = row.querySelector('.definition-archived');
+        const archiveButton = row.querySelector('.bi.bi-archive.clickable')
         if (archivedSpan) {
           archivedSpan.textContent = 'Yes';
+        }
+        if (archiveButton) {
+          archiveButton.remove();
         }
       }
     } catch (error) {
@@ -107,7 +111,7 @@ async function onArchive(event) {
 }
 
 function addRow(definitionsTable, definition) {
-  const showArchive = true;
+  const showArchive = !definition.isArchived;
 
   let row = definitionsTable.insertRow();
   row.definition = definition;


### PR DESCRIPTION
1. When listing an archived property the “Archive” button should not be visible
2. After archiving a definition the “Archive” button should disappear